### PR TITLE
Twitter login is successful, but problems remain.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -255,6 +255,10 @@ PODS:
     - FBSDKCoreKit (~> 5.5)
     - FBSDKLoginKit (~> 5.5)
     - Flutter
+  - flutter_twitter_login (0.0.1):
+    - Flutter
+    - TwitterCore (~> 3.2.0)
+    - TwitterKit (~> 3.4.0)
   - google_sign_in (0.0.1):
     - Flutter
     - GoogleSignIn (~> 5.0)
@@ -323,6 +327,9 @@ PODS:
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
   - PromisesObjC (1.2.8)
+  - TwitterCore (3.2.0)
+  - TwitterKit (3.4.2):
+    - TwitterCore (>= 3.2.0)
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -332,6 +339,7 @@ DEPENDENCIES:
   - firebase_core_web (from `.symlinks/plugins/firebase_core_web/ios`)
   - Flutter (from `Flutter`)
   - flutter_facebook_login (from `.symlinks/plugins/flutter_facebook_login/ios`)
+  - flutter_twitter_login (from `.symlinks/plugins/flutter_twitter_login/ios`)
   - google_sign_in (from `.symlinks/plugins/google_sign_in/ios`)
   - google_sign_in_web (from `.symlinks/plugins/google_sign_in_web/ios`)
 
@@ -363,6 +371,8 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PromisesObjC
+    - TwitterCore
+    - TwitterKit
 
 EXTERNAL SOURCES:
   cloud_firestore:
@@ -379,6 +389,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_facebook_login:
     :path: ".symlinks/plugins/flutter_facebook_login/ios"
+  flutter_twitter_login:
+    :path: ".symlinks/plugins/flutter_twitter_login/ios"
   google_sign_in:
     :path: ".symlinks/plugins/google_sign_in/ios"
   google_sign_in_web:
@@ -406,6 +418,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   flutter_facebook_login: cfb5659f686b1c575ef205c6b6fd20db9679d3c4
+  flutter_twitter_login: 1f670e60647cdf517ba20495e1b32046d9f22697
   google_sign_in: decaf71f56e22fb1dc179de062177ae6df415716
   google_sign_in_web: 52deb24929ac0992baff65c57956031c44ed44c3
   GoogleAppMeasurement: 39ecba10918b21c83877d392246157f65db351cf
@@ -420,6 +433,8 @@ SPEC CHECKSUMS:
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
   PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  TwitterCore: 8cbc9ad34d91c63a0035ea05bfbfc0d7ca72a28c
+  TwitterKit: 5e4f41d70b9abdb41df5467f52d7aa2c0fd26ebb
 
 PODFILE CHECKSUM: 57b6366e412a881a5db488ee35037f90711b962f
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,6 +53,7 @@
                 <array>
                     <string>com.googleusercontent.apps.339640322048-o15h07m5fue4vgk031sq7i8nhk4mukm6</string>
                     <string>fb202647027638404</string>
+                    <string>twitterkit-E78pLyZpDIt8MIVhfGtSWYu6s</string>
                 </array>
             </dict>
         </array>
@@ -62,8 +63,6 @@
         <key>FacebookAppID</key>
         <string>202647027638404</string>
         <key>FacebookDisplayName</key>
-
-        <!-- アプリ名に変更 -->
         <string>auth-flutter-sample</string>
 
         <key>LSApplicationQueriesSchemes</key>
@@ -72,6 +71,8 @@
             <string>fb-messenger-share-api</string>
             <string>fbauth2</string>
             <string>fbshareextension</string>
+            <string>twitter</string>
+            <string>twitterauth</string>
         </array>
 </dict>
 </plist>

--- a/lib/user_login/google_login_process.dart
+++ b/lib/user_login/google_login_process.dart
@@ -91,6 +91,8 @@ class _GoogleLoginProcessState extends State {
         children: [
           loggedIn ? loginText : logoutText,
           loggedIn ? logoutButton : loginButton,
+          // TODO ここにログイン完了後にアクセスするページを切り分ける処理を書くべきか？
+          // それともこのファイルの別の場所 55行目login()の前後か、はたまた呼び出し元か？
         ],
       ),
     );

--- a/lib/user_login/login_page.dart
+++ b/lib/user_login/login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'facebook_login_process.dart';
 import 'google_login_process.dart';
 import 'mail_login_form.dart';
+import 'twitter_login_process.dart';
 
 class LoginPage extends StatefulWidget {
   @override
@@ -18,17 +19,26 @@ class _LoginPageState extends State<LoginPage> {
         children: <Widget>[
           MailAndPassLogin(),
           Padding(
-            padding: EdgeInsets.all(16.0),
+            padding: EdgeInsets.all(8.0),
             child: Text('----------'),
           ),
           GoogleLoginProcess(),
           Padding(
-            padding: EdgeInsets.all(16.0),
+            padding: EdgeInsets.all(8.0),
             child: Text('----------'),
           ),
           FacebookLoginProcess(),
+          Padding(
+            padding: EdgeInsets.all(8.0),
+            child: Text('----------'),
+          ),
+          TwitterLoginProcess(),
         ],
       ),
     );
   }
 }
+
+// TODO
+// 各SNSログインページ（mail_login_formを除く）にある setState(bool loggedIn)を使って
+// ログイン済み・未ログインの切り替えができないか？

--- a/lib/user_login/mail_login_form.dart
+++ b/lib/user_login/mail_login_form.dart
@@ -1,10 +1,12 @@
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:fireflutter/user_login/user_logged_in.dart';
 import 'package:flutter/material.dart';
 
 class MailAndPassLogin extends StatelessWidget {
   // Login with email and password
   final emailInputController = TextEditingController();
   final passwordInputController = TextEditingController();
+  //UserLoggedIn _userLoggedIn
 
   @override
   Widget build(BuildContext context) {
@@ -40,9 +42,10 @@ class MailAndPassLogin extends StatelessWidget {
                     var email = emailInputController.text;
                     var password = passwordInputController.text;
                     // ログイン処理(別途Firebase管理画面でユーザー登録が必要)
-                    return _signIn(email, password)
-                        .then((AuthResult result) => print(result.user))
-                        .catchError((e) => print(e));
+                    return _signIn(email, password).then((AuthResult result) {
+                      print(result.user);
+                      UserLoggedIn();
+                    }).catchError((e) => print(e));
                   },
                 ),
               ),

--- a/lib/user_login/twitter_login_process.dart
+++ b/lib/user_login/twitter_login_process.dart
@@ -1,122 +1,100 @@
-//import 'package:flutter/material.dart';
-//import 'package:firebase_auth/firebase_auth.dart';
-//import 'package:flutter_twitter_login/flutter_twitter_login.dart';
-//
-//void main() => runApp(MyApp());
-//
-//class MyApp extends StatelessWidget {
-//  @override
-//  Widget build(BuildContext context) {
-//    return MaterialApp(
-//      title: 'auth sample',
-//      theme: ThemeData(
-//        primarySwatch: Colors.blue,
-//      ),
-//      home: AuthPage(
-//        title: 'Auth Sample with Firebase',
-//      ),
-//    );
-//  }
-//}
-//
-//class AuthPage extends StatefulWidget {
-//  AuthPage({
-//    Key key,
-//    this.title,
-//  }) : super(
-//    key: key,
-//  );
-//
-//  final String title;
-//
-//  @override
-//  _AuthPageState createState() => _AuthPageState();
-//}
-//
-//class _AuthPageState extends State {
-//  final FirebaseAuth _auth = FirebaseAuth.instance;
-//
-//  // APIキーを入力
-//  final TwitterLogin twitterLogin = TwitterLogin(
-//    consumerKey: consumerKey,
-//    consumerSecret: secretkey,
-//  );
-//
-//  bool logined = false;
-//
-//  void login() {
-//    setState(() {
-//      logined = true;
-//    });
-//  }
-//
-//  void logout() {
-//    setState(() {
-//      logined = false;
-//    });
-//  }
-//
-//  Future signInWithTwitter() async {
-//    // twitter認証の許可画面が出現
-//    final TwitterLoginResult result = await twitterLogin.authorize();
-//
-//    //Firebaseのユーザー情報にアクセス & 情報の登録 & 取得
-//    final AuthCredential credential = TwitterAuthProvider.getCredential(
-//      authToken: result.session.token,
-//      authTokenSecret: result.session.secret,
-//    );
-//
-//    //Firebaseのuser id取得
-//    final FirebaseUser user =
-//        (await _auth.signInWithCredential(credential)).user;
-//
-//    assert(!user.isAnonymous);
-//    assert(await user.getIdToken() != null);
-//
-//    final FirebaseUser currentUser = await _auth.currentUser();
-//    assert(user.uid == currentUser.uid);
-//
-//    login();
-//  }
-//
-//  void signOutTwitter() async {
-//    await twitterLogin.logOut();
-//    logout();
-//    print("User Sign Out Twittter");
-//  }
-//
-//  @override
-//  Widget build(BuildContext context) {
-//    Widget logoutText = Text("ログアウト中");
-//    Widget loginText = Text("ログイン中");
-//
-//    Widget loginBtnTwitter = RaisedButton(
-//      child: Text("Sign in with Twitter"),
-//      color: Color(0xFF1DA1F2),
-//      textColor: Colors.white,
-//      onPressed: signInWithTwitter,
-//    );
-//    Widget logoutBtnTwitter = RaisedButton(
-//      child: Text("Sign out with Twitter"),
-//      color: Color(0xFF1DA1F2),
-//      textColor: Colors.white,
-//      onPressed: signOutTwitter,
-//    );
-//
-//    return Scaffold(
-//      appBar: AppBar(
-//        centerTitle: true,
-//        title: Text(widget.title),
-//      ),
-//      body: Center(
-//        child: Column(
-//          mainAxisAlignment: MainAxisAlignment.center,
-//          children: [
-//            logined ? loginText : logoutText,
-//            logined ? logoutBtnTwitter : loginBtnTwitter,
-//          ],
-//        ),
-//      ),
-//    );
-//  }
-//}
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_twitter_login/flutter_twitter_login.dart';
+
+class TwitterLoginProcess extends StatefulWidget {
+  TwitterLoginProcess({
+    Key key,
+    this.title,
+  }) : super(
+          key: key,
+        );
+
+  final String title;
+
+  @override
+  _TwitterLoginProcessState createState() => _TwitterLoginProcessState();
+}
+
+class _TwitterLoginProcessState extends State {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  // APIキーを入力
+  final TwitterLogin twitterLogin = TwitterLogin(
+    // TODO 動くが、公開予定のプログラム中にAPI Keyを直接記述するのはアウトだろう
+    consumerKey: "consumer-key",
+    consumerSecret: "consumer-secret",
+  );
+
+  bool loggedIn = false;
+
+  void login() {
+    setState(() {
+      loggedIn = true;
+    });
+  }
+
+  void logout() {
+    setState(() {
+      loggedIn = false;
+    });
+  }
+
+  Future signInWithTwitter() async {
+    // twitter認証の許可画面が出現
+    final TwitterLoginResult result = await twitterLogin.authorize();
+
+    //Firebaseのユーザー情報にアクセス & 情報の登録 & 取得
+    final AuthCredential credential = TwitterAuthProvider.getCredential(
+      authToken: result.session.token,
+      authTokenSecret: result.session.secret,
+    );
+
+    //Firebaseのuser id取得
+    final FirebaseUser user =
+        (await _auth.signInWithCredential(credential)).user;
+
+    assert(!user.isAnonymous);
+    assert(await user.getIdToken() != null);
+
+    final FirebaseUser currentUser = await _auth.currentUser();
+    assert(user.uid == currentUser.uid);
+
+    login();
+  }
+
+  void signOutTwitter() async {
+    await twitterLogin.logOut();
+    logout();
+    print("User Sign Out Twittter");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget logoutText = Text("ログアウト中");
+    Widget loginText = Text("ログイン中");
+
+    Widget loginBtnTwitter = RaisedButton(
+      child: Text("Sign in with Twitter"),
+      color: Color(0xFF1DA1F2),
+      textColor: Colors.white,
+      onPressed: signInWithTwitter,
+    );
+    Widget logoutBtnTwitter = RaisedButton(
+      child: Text("Sign out with Twitter"),
+      color: Color(0xFF1DA1F2),
+      textColor: Colors.white,
+      onPressed: signOutTwitter,
+    );
+
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          loggedIn ? loginText : logoutText,
+          loggedIn ? logoutBtnTwitter : loginBtnTwitter,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/user_login/user_logged_in.dart
+++ b/lib/user_login/user_logged_in.dart
@@ -1,10 +1,16 @@
 class UserLoggedIn {
+//  String _loggedInUserId = null;
+//
+//  String userLoggedIn(AuthResult result) {
+//    if (result != null) {
+//      _loggedInUserId = result.user.uid;
+//    }
+//    return _loggedInUserId;
+//  }
+
   bool _loggedIn = false;
 
   bool userLoggedIn() {
-//    if (_authUserExists == true) {
-//      _loggedIn = true;
-//    }
     return _loggedIn;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,15 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_twitter_login:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: aba1223f224fd46b564d582e1f9af82f1a2df7d0
+      url: "git://github.com/eudangeld/flutter_twitter_login.git"
+    source: git
+    version: "1.1.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,11 +9,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  firebase_core: 0.4.4
-  cloud_firestore: 0.13.4
-  firebase_auth: 0.15.0
-  google_sign_in: 4.1.4
-  flutter_facebook_login: 3.0.0
+  firebase_core: ^0.4.4
+  cloud_firestore: ^0.13.4
+  firebase_auth: ^0.15.0
+  google_sign_in: ^4.1.4
+  flutter_facebook_login: ^3.0.0
+  #flutter_twitter_login: ^1.1.0
+  flutter_twitter_login:
+    git:
+      url: git://github.com/eudangeld/flutter_twitter_login.git
 
   cupertino_icons: ^0.1.3
 


### PR DESCRIPTION
問題点：
- Twitterログインでプログラム中に直接API Key、API Key secretを文字列リテラルで書き込んでいる
- メールアドレスログインはできているが、新規登録が用意できていない
- ログイン後の画面遷移ができてない
  - bool loggedInやString userIdを判定材料として渡すか、AuthResultやuserなどを丸ごと渡すか？
  - 各認証方法を別々のクラス、dartファイルとして分けているが上記をどの場所でどのように渡すか
- 上記全てを部品分けせずに一塊に記述したソースコードを探し、完全に置き換えて解決とするか

いずれにせよ、当初2人日の予定だったログイン機能部分に拘ってアプリ本体部分の開発を遅らせるべきではない。